### PR TITLE
Refactor to exclude the assigning user from notifications

### DIFF
--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -178,7 +178,7 @@ class Task extends Model
 
         if ($assignedTo->isNotEmpty()) {
             $task->users()->attach(id: $assignedTo->mapWithKeys(fn (int $id) => [$id => ['assigned_by' => $userId]]));
-            $assignedToUsers = User::whereIn('id', $assignedTo)->get();
+            $assignedToUsers = User::whereIn('id', $assignedTo->filter(fn (int $id) => $id !== $userId))->get();
             Notification::send($assignedToUsers, new TaskAssigned($task));
         }
 
@@ -238,7 +238,7 @@ class Task extends Model
             if ($assignedToDiff->isNotEmpty()) {
                 $this->users()->attach($assignedToDiff->mapWithKeys(fn(int $id) => [$id => ['assigned_by' => $userId]]));
 
-                $assignedToUsers = User::whereIn('id', $assignedToDiff)->get();
+                $assignedToUsers = User::whereIn('id', $assignedToDiff->filter(fn (int $id) => $id !== $userId))->get();
                 Notification::send($assignedToUsers, new TaskAssigned($this));
             }
 


### PR DESCRIPTION
- Updated the logic in createFrom and updateFrom methods to filter out the user who is assigning the task from the notification recipients.
- Ensured that only users other than the assigning user receive task assignment notifications.