### PR TITLE
Refactor subtask handling in CreateSubtask and UpdateSubtask actions

### DIFF
--- a/app/Actions/CreateSubtask.php
+++ b/app/Actions/CreateSubtask.php
@@ -4,7 +4,6 @@ namespace App\Actions;
 
 use App\Enums\TaskPriority;
 use App\Enums\TaskProgress;
-use App\Http\Resources\TaskResource;
 use App\Models\Task;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -33,7 +32,7 @@ class CreateSubtask
         Task::createFrom($fields, $request->user(), $request->header('X-Timezone'));
 
         Inertia::flash([
-            'subtasks' => TaskResource::collection(Task::where('task_id', $fields['task_id'])->with('users', 'buckets', 'projects', 'tasks', 'createdBy', 'task')->ordered()->get()),
+            'task_id' => $fields['task_id'],
         ]);
 
         return response()->redirectTo($request->header('X-From'));

--- a/app/Actions/UpdateSubtask.php
+++ b/app/Actions/UpdateSubtask.php
@@ -4,7 +4,6 @@ namespace App\Actions;
 
 use App\Enums\TaskPriority;
 use App\Enums\TaskProgress;
-use App\Http\Resources\TaskResource;
 use App\Models\Task;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -34,7 +33,7 @@ class UpdateSubtask
         $subtask->updateFrom($fields, $request->user(), $request->header('X-Timezone'));
 
         Inertia::flash([
-            'subtasks' => TaskResource::collection(Task::where('task_id', $subtask->task_id)->with('users', 'buckets', 'projects', 'tasks', 'createdBy', 'task')->ordered()->get()),
+            'task_id' => $subtask->task_id,
         ]);
 
         return response()->redirectTo($request->header('X-From'));

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,12 +4,15 @@ namespace App\Http\Middleware;
 
 use App\Http\Resources\BucketResource;
 use App\Http\Resources\ProjectResource;
+use App\Http\Resources\TaskResource;
 use App\Http\Resources\UserResource;
 use App\Models\Project;
+use App\Models\Task;
 use App\Models\User;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
@@ -51,6 +54,8 @@ class HandleInertiaRequests extends Middleware
             ? User::with(['projects'])->where('organization_id', $request->user()->organization_id)->get()
             : collect();
 
+        $subtasks = $request->session()->get('inertia.flash_data.task_id') ? TaskResource::collection(Task::query()->where('task_id', $request->session()->get('inertia.flash_data.task_id'))->with('users', 'buckets', 'projects', 'tasks', 'createdBy', 'task')->ordered()->get()) : null;
+
         return [
             ...parent::share($request),
             ...$request->session()->get('inertia', []),
@@ -61,6 +66,7 @@ class HandleInertiaRequests extends Middleware
                 'your_buckets' => BucketResource::collection($yourBuckets),
                 'assignable_users' => UserResource::collection($users),
             ] : [],
+            'subtasks' => $subtasks,
             'auth' => [
                 'user' => $request->user(),
             ],

--- a/resources/js/components/TaskModal.vue
+++ b/resources/js/components/TaskModal.vue
@@ -166,7 +166,7 @@ function onNewTaskSubmit() {
     store.onSubTaskFormSubmitCreate(newTaskName.value, props.page, function (results) {
       emit('updatedTasks', results);
       addTaskMode.value = false;
-      tasks.value = results.flash.subtasks;
+      tasks.value = results.props.subtasks;
       newTaskName.value = '';
     });
   } else {
@@ -195,7 +195,7 @@ function onEditSubTask(subTask) {
 function updateSubTaskStatus(subTaskId, newStatus) {
   store.onSubTaskFormSubmitUpdateStatus(subTaskId, newStatus, props.page, function (results) {
     emit('updatedTasks', results);
-    tasks.value = results.flash.subtasks;
+    tasks.value = results.props.subtasks;
   });
 }
 

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,7 +3,6 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-        <link rel="icon" href="/favicon.ico" sizes="any">
         <link rel="icon" href="/favicon.svg" type="image/svg+xml">
         <title inertia>{{ config('app.name', 'Project Manager') }}</title>
         @routes


### PR DESCRIPTION
- Removed unused TaskResource references in CreateSubtask and UpdateSubtask actions.
- Updated Inertia flash data to only include 'task_id' instead of 'subtasks'.
- Modified HandleInertiaRequests middleware to conditionally retrieve subtasks based on the session data.
- Adjusted TaskModal component to access subtasks from props instead of flash data.
- Cleaned up app layout by removing the old favicon link.