### PR TITLE
Refactor Task and User models to remove 'notified_at' from pivot rela…

### DIFF
--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -63,7 +63,7 @@ class Task extends Model
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(User::class)->withPivot('assigned_by', 'notified_at')->withTimestamps();
+        return $this->belongsToMany(User::class)->withPivot('assigned_by')->withTimestamps();
     }
 
     public function projects(): BelongsToMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -96,7 +96,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
     public function tasks(): BelongsToMany
     {
-        return $this->belongsToMany(Task::class)->withPivot('assigned_by', 'notified_at')->withTimestamps()->orderByRaw('(completed_at IS NOT NULL) ASC')
+        return $this->belongsToMany(Task::class)->withPivot('assigned_by')->withTimestamps()->orderByRaw('(completed_at IS NOT NULL) ASC')
             ->orderByRaw('(started_at IS NOT NULL) ASC')
             ->orderByRaw('(due_at IS NULL) ASC')
             ->orderBy('due_at')


### PR DESCRIPTION
…tionships

- Updated the users() method in Task model to exclude 'notified_at' from the pivot fields.
- Adjusted the tasks() method in User model to also remove 'notified_at' from the pivot fields while maintaining existing ordering logic.