### PR TITLE
Add ShabbatZoomLink email functionality

### DIFF
--- a/app/Mail/ShabbatZoomLink.php
+++ b/app/Mail/ShabbatZoomLink.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+
+class ShabbatZoomLink extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public ?Carbon $date = null,
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        $dateString = $this->date ? $this->date->timezone('America/New_York')->format('M j, Y') : now('America/New_York')->addDays(2)->format('M j, Y');
+
+        return new Envelope(
+            from: new Address('aaron@ironmthome.com', 'Aaron Eisenberg'),
+            subject: 'Baruch Haba is inviting you to a scheduled Zoom meeting.  Topic: Shabbat Service Baruch Haba Time: ' . $dateString . ' 11:00 AM',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            text: 'email.zoom-link',
+            with: [
+                'dateString' => $this->date ? $this->date->timezone('America/New_York')->format('M j, Y') : now('America/New_York')->addDays(2)->format('M j, Y'),
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,12 +4,14 @@ use App\Http\Middleware\HandleInertiaRequests;
 use App\Models\User;
 use App\Notifications\TasksDue;
 use App\Notifications\TasksStale;
+use App\Mail\ShabbatZoomLink;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 use Sentry\Laravel\Integration;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -114,6 +116,14 @@ return Application::configure(basePath: dirname(__DIR__))
                 $user->notify(new TasksStale($user->tasks, 30));
             }
         })->hourly();
+
+        $schedule->call(function () {
+            Mail::mailer('smtp')->to('aaron@ironmthome.com')->bcc('rod@ironmthome.com')->send(new ShabbatZoomLink());
+        })->weeklyOn(6, '17:00')->timezone('America/New_York'); // Thursday at 5:00 PM EST
+
+        $schedule->call(function () {
+            Mail::mailer('smtp')->to('aaron@ironmthome.com')->bcc('rod@ironmthome.com')->send(new ShabbatZoomLink(now('America/New_York')));
+        })->monthlyOn(13, '00:10')->timezone('America/New_York'); // 12:10 AM EST on the 13th of the month
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->respond(function (Response $response, Throwable $exception, Request $request) {

--- a/resources/views/email/zoom-link.blade.php
+++ b/resources/views/email/zoom-link.blade.php
@@ -1,0 +1,16 @@
+Baruch Haba is inviting you to a scheduled Zoom meeting.
+
+Topic: Shabbat Service Baruch Haba
+Time: {{ $dateString }} 11:00 AM
+
+Join Zoom Meeting
+https://us02web.zoom.us/j/86290954840?pwd=ZGnBt0TcQaLhbRZaRiICNaF7daX7rM.1
+
+
+Meeting ID: 862 9095 4840
+Passcode: 645208
+
+---
+
+One tap mobile
++13092053325,,86290954840#,,,,*645208#


### PR DESCRIPTION
- Introduced a new Mailable class `ShabbatZoomLink` for sending Zoom meeting invitations.
- Scheduled weekly and monthly email dispatches using Laravel's task scheduling.
- Created a new Blade view `zoom-link.blade.php` for the email content, including meeting details and a join link.